### PR TITLE
TestAddNeighbors failing for correct submissions (MacOS and Windows) fix

### DIFF
--- a/test/utest_rp_a_star_search.cpp
+++ b/test/utest_rp_a_star_search.cpp
@@ -76,9 +76,11 @@ TEST_F(RoutePlannerTest, TestAddNeighbors) {
     route_planner.AddNeighbors(start_node);
 
     // Correct h and g values for the neighbors of start_node.
-    std::vector<float> start_neighbor_g_vals{0.10671431, 0.082997195, 0.051776856, 0.055291083};
-    std::vector<float> start_neighbor_h_vals{1.1828455, 1.0998145, 1.0858033, 1.1831238};
+    std::vector<float> start_neighbor_g_vals{ 0.051776856, 0.055291083, 0.082997195, 0.10671431 };
+    std::vector<float> start_neighbor_h_vals{ 1.0858033, 1.1831238, 1.0998145, 1.1828455 };
     auto neighbors = start_node->neighbors;
+    std::sort(std::begin(neighbors), std::end(neighbors),
+        [](RouteModel::Node* a, RouteModel::Node* b) { return a->g_value < b->g_value; });
     EXPECT_EQ(neighbors.size(), 4);
 
     // Check results for each neighbor.


### PR DESCRIPTION
Just sort the vectors by the g value before comparing them, as a workaround to keep the test result consistent on the other platforms.