### PR TITLE
Fix Issue #18

### DIFF
--- a/src/model.cpp
+++ b/src/model.cpp
@@ -44,7 +44,18 @@ Model::Model( const std::vector<std::byte> &xml )
     AdjustCoordinates();
 
     std::sort(m_Roads.begin(), m_Roads.end(), [](const auto &_1st, const auto &_2nd){
-        return (int)_1st.type < (int)_2nd.type; 
+        if (_1st.type < _2nd.type)
+        {
+            return 1;
+        }
+        else if (_1st.way < _2nd.way)
+        {
+            return 1;
+        }
+        else
+        {
+            return 0;
+        }
     });
 }
 

--- a/test/utest_rp_a_star_search.cpp
+++ b/test/utest_rp_a_star_search.cpp
@@ -76,8 +76,8 @@ TEST_F(RoutePlannerTest, TestAddNeighbors) {
     route_planner.AddNeighbors(start_node);
 
     // Correct h and g values for the neighbors of start_node.
-    std::vector<float> start_neighbor_g_vals{0.10671431, 0.082997195, 0.051776856, 0.055291083};
-    std::vector<float> start_neighbor_h_vals{1.1828455, 1.0998145, 1.0858033, 1.1831238};
+    std::vector<float> start_neighbor_g_vals{0.082997195, 0.10671431, 0.055291083, 0.051776856};
+    std::vector<float> start_neighbor_h_vals{1.0998145, 1.1828455, 1.1831238, 1.0858033};
     auto neighbors = start_node->neighbors;
     EXPECT_EQ(neighbors.size(), 4);
 


### PR DESCRIPTION
Changing Sort function for Model consructor class to assure the same results on different platform.  To have the same order after the sort based on two values instead of one.  Now, m_Roads sorted is the same independent of the platform.