### PR TITLE
Remove *.osm in gitignore if map.osm  must be submitted with project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.swp
 *.osm
+!map.osm
 *.o
 draw.cpp
 test.cpp


### PR DESCRIPTION
I received a review saying we must commit this file with our submission. the *.osm constraint prevent the map.osm to be committed. I suggest adding an extra line to fix this.